### PR TITLE
Fix #73 #43 - Have a time to live on location and time data.

### DIFF
--- a/src/main/js/intents/repeat.js
+++ b/src/main/js/intents/repeat.js
@@ -1,21 +1,26 @@
 "use strict";
 
 var winston = require("winston");
-
-module.exports = function (bot, persona) {
+var convData = require('./utils').convData;
+module.exports = function(bot, persona) {
 
     var intent = "repeat";
 
     bot.dialog(intent, [
-        function (session, results) {
+        function(session, results, next) {
             winston.info("[ %s ] intent matched [ %s ]", intent, session.message.text);
-            if(session.conversationData.previous_intent) {
+            if (session.conversationData.previous_intent) {
+                convData.addWithExpiry(session, 'isRepeat', true, convData.MINUTE * 3);
                 session.beginDialog(session.conversationData.previous_intent, results);
+                next();
             } else {
                 session.send(persona.getResponse("error.general"));
                 session.endDialog();
             }
-        }]
-    );
+        },
+        function(session, results, next) {
+            convData.deleteItem('isRepeat');
+        }
+    ]);
 
 };

--- a/src/main/js/intents/repeat.js
+++ b/src/main/js/intents/repeat.js
@@ -16,11 +16,13 @@ module.exports = function(bot, persona) {
                 session.beginDialog(session.conversationData.previous_intent, results);
                 next();
             } else {
+                convData.deleteItem('isRepeat');
                 session.send(persona.getResponse("error.general"));
                 session.endDialog();
             }
         },
         function(session, results, next) {
+            console.error('delete repete');
             convData.deleteItem('isRepeat');
         }
     ]);

--- a/src/main/js/intents/utils/capture.js
+++ b/src/main/js/intents/utils/capture.js
@@ -30,11 +30,10 @@ module.exports = {
 
         winston.debug("capturing datetimeV2");
         var luis = session.conversationData.luis;
-        var ttl = 3 * convData.HOUR;
         if (luis && luis.entities) {
             var datetimeEntity = luis.entities.filter(e => e.type.includes("datetimeV2"))[0];
             if (datetimeEntity) {
-                convData.addWithExpiry(session, 'time_target', datetimeEntity, ttl);
+                convData.addWithExpiry(session, 'time_target', datetimeEntity);
             }
         }
 

--- a/src/main/js/intents/utils/capture.js
+++ b/src/main/js/intents/utils/capture.js
@@ -56,7 +56,7 @@ module.exports = {
             };
         }
         time_target.text = timeEntityToMsgText(time_target);
-        convData.addWithExpiry(session, 'time_target', time_target, ttl);
+        convData.addWithExpiry(session, 'time_target', time_target);
         return next();
     },
 

--- a/src/main/js/intents/utils/convData.js
+++ b/src/main/js/intents/utils/convData.js
@@ -1,0 +1,54 @@
+var cache = require("js-cache");
+var HOUR = 1000 * 60 * 60;
+var MINUTE = 1000 * 60;
+var DAY = HOUR * 24;
+
+function getAll(session) {
+    // Get the conversation data from the session. Creates empty if doesn't exist
+    var data = session.conversationData;
+    if (!data) {
+        data = {};
+        session.conversationData = data;
+    }
+    return data;
+}
+
+function addWithExpiry(session, key, data, ttl) {
+    // Add data to session.convData data with key marking it as expiaring in ttl ms.
+    // ttl defaults to 1 hours
+    ttl = isNaN(ttl) ? HOUR : ttl;
+    var expireAt = (new Date()).getTime() + ttl;
+    getAll(session)[key] = {
+        value: data,
+        expireAt: expireAt
+    }
+}
+
+function deleteItem(session, key) {
+    delete getAll(session)[key];
+}
+
+function get(session, key) {
+    // Gets the data if not expired. If expired or not found return undefined.
+    var data = getAll(session)[key];
+    if (!data) {
+        return;
+    }
+    if (!data.expireAt) {
+        return data; // If no expireAt then assume not managed using this util so just return as is.
+    }
+    if (data.expireAt === -1 || data.expireAt > (new Date()).getTime()) {
+        return data.value;
+    } else {
+        delete getAll(session)[key];
+    }
+    return;
+}
+
+module.exports = {
+    get: get,
+    addWithExpiry: addWithExpiry,
+    HOUR: HOUR,
+    DAY: DAY,
+    deleteItem: deleteItem
+}

--- a/src/main/js/intents/utils/index.js
+++ b/src/main/js/intents/utils/index.js
@@ -20,3 +20,5 @@ exports.summarize = require('./summarize');
 exports.capture = require('./capture');
 
 exports.convData = require('./convData');
+
+exports.time = require('./timeUtils');

--- a/src/main/js/intents/utils/index.js
+++ b/src/main/js/intents/utils/index.js
@@ -18,3 +18,5 @@ exports.sanitze = require('./sanitze');
 exports.summarize = require('./summarize');
 
 exports.capture = require('./capture');
+
+exports.convData = require('./convData');

--- a/src/main/js/intents/utils/sanitze.js
+++ b/src/main/js/intents/utils/sanitze.js
@@ -3,6 +3,7 @@
 var sugar = require("sugar");
 var winston = require("winston");
 var convData = require('./convData');
+var timeUtils = require('./timeUtils');
 
 // TODO: Split out this in to moudles. 
 
@@ -197,7 +198,7 @@ module.exports = {
     weather: (session, results, next) => {
         var fcstArray = session.conversationData.datapoint.features[0].properties.time_series;
 
-        var range = convData.get(session, 'time_target').range;
+        var range = timeUtils.rangeStrsToObjs(convData.get(session, 'time_target').range);
 
         fcstArray = fcstArray.filter(x => {
             var dt = sugar.Date.create(x.time);

--- a/src/main/js/intents/utils/sanitze.js
+++ b/src/main/js/intents/utils/sanitze.js
@@ -2,6 +2,7 @@
 
 var sugar = require("sugar");
 var winston = require("winston");
+var convData = require('./convData');
 
 // TODO: Split out this in to moudles. 
 
@@ -12,10 +13,10 @@ module.exports = {
 
     /**
      * Parses the user's response to extract the user specified location.
-     * Sets the session.conversationData.location property
+     * Sets the convData 'location'  property
      */
     location: (session, results, next) => {
-        var str = session.conversationData.location.toLowerCase();
+        var str = convData.get(session, 'location').toLowerCase();
         winston.debug(`sanitizing [ ${str} ] for a location`);
 
         /* location regex
@@ -42,7 +43,7 @@ module.exports = {
             result = strRegexResults[strRegexResults.length - 1].trim();
             result = sugar.String.capitalize(result, true, true);
         }
-        session.conversationData.location = result;
+        convData.addWithExpiry(session, 'location', result);
         return next();
     },
 
@@ -81,10 +82,9 @@ module.exports = {
         return next();
     },
 
-    //TODO: make this return a single object { 'fromDT': x, 'toDT': y }
     datetimeV2: (session, results, next) => {
 
-        var dt = session.conversationData.time_target;
+        var dt = convData.get(session, 'time_target');
         var dtType = dt.type.split('.')[2];
         var range = null;
         switch (dtType) {
@@ -107,7 +107,7 @@ module.exports = {
                 throw `unrecognised datetimeV2 entity type [${dtType}]`;
         }
 
-        session.conversationData.time_target.range = range;
+        dt.range = range;
 
         return next();
 
@@ -196,7 +196,8 @@ module.exports = {
      */
     weather: (session, results, next) => {
         var fcstArray = session.conversationData.datapoint.features[0].properties.time_series;
-        var range = session.conversationData.time_target.range;
+
+        var range = convData.get(session, 'time_target').range;
 
         fcstArray = fcstArray.filter(x => {
             var dt = sugar.Date.create(x.time);

--- a/src/main/js/intents/utils/timeUtils.js
+++ b/src/main/js/intents/utils/timeUtils.js
@@ -1,0 +1,12 @@
+"use strict";
+
+var sugar = require("sugar");
+
+module.exports = {
+    rangeStrsToObjs: function(range) {
+        return {
+            fromDT: sugar.Date.create(range.fromDT),
+            toDT: sugar.Date.create(range.toDT)
+        }
+    }
+}

--- a/src/main/js/intents/weather/accessory.js
+++ b/src/main/js/intents/weather/accessory.js
@@ -47,7 +47,9 @@ module.exports = (bot, persona, datapoint, gmaps) => {
                 });
         },
         (session, results, next) => {
-            var end = utils.convData.get(session, 'time_target').range.toDT;
+            var range = utils.convData.get(session, 'time_target').range;
+            range = utils.time.rangeStrsToObjs(range);
+            var end = range.toDT;
             datapoint.getMethodForTargetTime(end)(session.conversationData.gmaps.results[0].geometry.location.lat, session.conversationData.gmaps.results[0].geometry.location.lng)
                 .then((res) => {
                     session.conversationData.datapoint = res;

--- a/src/main/js/intents/weather/accessory.js
+++ b/src/main/js/intents/weather/accessory.js
@@ -35,7 +35,7 @@ module.exports = (bot, persona, datapoint, gmaps) => {
         utils.sanitze.datetimeV2,
         utils.capture.accessory,
         (session, results, next) => {
-            gmaps.geocode(session.conversationData.location)
+            gmaps.geocode(utils.convData.get(session, 'location'))
                 .then((res) => {
                     session.conversationData.gmaps = res;
                     return next();
@@ -47,7 +47,7 @@ module.exports = (bot, persona, datapoint, gmaps) => {
                 });
         },
         (session, results, next) => {
-            var end = session.conversationData.time_target.range.toDT;
+            var end = utils.convData.get(session, 'time_target').range.toDT;
             datapoint.getMethodForTargetTime(end)(session.conversationData.gmaps.results[0].geometry.location.lat, session.conversationData.gmaps.results[0].geometry.location.lng)
                 .then((res) => {
                     session.conversationData.datapoint = res;
@@ -62,12 +62,13 @@ module.exports = (bot, persona, datapoint, gmaps) => {
         utils.sanitze.weather,
         utils.summarize.weather,
         (session, results, next) => {
-            var accessorySlug = sugar.String.underscore(session.conversationData.accessory.toLowerCase());
+            var accessory = utils.convData.get(session, 'accessory');
+            var accessorySlug = sugar.String.underscore(accessory.toLowerCase());
             var accessoryIntent = `${intent}.${accessorySlug}`;
             if (session.library.dialogs[accessoryIntent]) {
                 session.beginDialog(accessoryIntent);
             } else {
-                winston.warn("accessory [ %s ] did not match with any known accessories", session.conversationData.accessory);
+                winston.warn("accessory [ %s ] did not match with any known accessories", accessory);
                 var unknown = `${intent}.unknown`;
                 session.beginDialog(unknown);
             }

--- a/src/main/js/intents/weather/action/action.js
+++ b/src/main/js/intents/weather/action/action.js
@@ -35,7 +35,7 @@ module.exports = (bot, persona, datapoint, gmaps) => {
         utils.sanitze.datetimeV2,
         utils.capture.action,
         (session, results, next) => {
-            gmaps.geocode(session.conversationData.location)
+            gmaps.geocode(utils.convData.get(session, 'location'))
                 .then((res) => {
                     session.conversationData.gmaps = res;
                     return next();
@@ -47,7 +47,7 @@ module.exports = (bot, persona, datapoint, gmaps) => {
                 });
         },
         (session, results, next) => {
-            var end = session.conversationData.time_target.range.toDT;
+            var end = utils.convData.get(session, 'time_target').range.toDT;
             datapoint.getMethodForTargetTime(end)(session.conversationData.gmaps.results[0].geometry.location.lat, session.conversationData.gmaps.results[0].geometry.location.lng)
                 .then((res) => {
                     session.conversationData.datapoint = res;
@@ -62,12 +62,12 @@ module.exports = (bot, persona, datapoint, gmaps) => {
         utils.sanitze.weather,
         utils.summarize.weather,
         (session, results, next) => {
-            var actionType = session.conversationData.action_type;
+            var actionType = utils.convData.get(session, 'action_type');
             var actionIntent = `${intent}.${actionType}`;
             if (session.library.dialogs[actionIntent]) {
                 session.beginDialog(actionIntent);
             } else {
-                winston.warn("accessory [ %s ] did not match with any known actionType", session.conversationData.actionType);
+                winston.warn("accessory [ %s ] did not match with any known actionType", actionType);
                 var unknown = `${intent}.unknown`;
                 session.beginDialog(unknown);
             }

--- a/src/main/js/intents/weather/action/action.js
+++ b/src/main/js/intents/weather/action/action.js
@@ -47,7 +47,9 @@ module.exports = (bot, persona, datapoint, gmaps) => {
                 });
         },
         (session, results, next) => {
-            var end = utils.convData.get(session, 'time_target').range.toDT;
+            var range = utils.convData.get(session, 'time_target').range;
+            range = utils.time.rangeStrsToObjs(range);
+            var end = range.toDT;
             datapoint.getMethodForTargetTime(end)(session.conversationData.gmaps.results[0].geometry.location.lat, session.conversationData.gmaps.results[0].geometry.location.lng)
                 .then((res) => {
                     session.conversationData.datapoint = res;
@@ -55,7 +57,7 @@ module.exports = (bot, persona, datapoint, gmaps) => {
                 })
                 .catch((err) => {
                     winston.warn(err);
-                    if(err.response_id) {
+                    if (err.response_id) {
                         session.send(persona.getResponse(err.response_id));
                     } else {
                         session.send(persona.getResponse("error.data.not_returned"));

--- a/src/main/js/intents/weather/detail.js
+++ b/src/main/js/intents/weather/detail.js
@@ -28,9 +28,10 @@ module.exports = (bot, persona) => {
                 .send();
             session.conversationData.luis = results;
             session.conversationData.intent = intent;
-
-            if (!session.conversationData.time_target || !session.conversationData.location) {
-                winston.warn("[ %s ] matched but the time_target was [ %s ] and the location was [ %s ]", intent, session.conversationData.time_target, session.conversationData.location);
+            var time_target = utils.convData.get(session, 'time_target');
+            var location = utils.convData.get(session, 'location')
+            if (!time_target || !location) {
+                winston.warn("[ %s ] matched but the time_target was [ %s ] and the location was [ %s ]", intent, time_target, location);
                 session.cancelDialog();
                 session.beginDialog("error.nonsense");
             }
@@ -46,9 +47,9 @@ module.exports = (bot, persona) => {
             var response = "";
             var model = {
                 user: session.userData,
-                location: session.conversationData.location,
+                location: utils.convData.get(session, 'location'),
                 date: {
-                    day_string: session.conversationData.time_target.text
+                    day_string: utils.convData.get(session, 'time_target').text
                 }
             };
 

--- a/src/main/js/intents/weather/forecast.js
+++ b/src/main/js/intents/weather/forecast.js
@@ -50,7 +50,9 @@ module.exports = (bot, persona, datapoint, gmaps) => {
                 });
         },
         (session, results, next) => {
-            var end = utils.convData.get(session, 'time_target').range.toDT;
+            var range = utils.convData.get(session, 'time_target').range;
+            range = utils.time.rangeStrsToObjs(range);
+            var end = range.toDT;
             datapoint.getMethodForTargetTime(end)(session.conversationData.gmaps.results[0].geometry.location.lat, session.conversationData.gmaps.results[0].geometry.location.lng)
                 .then((res) => {
                     session.conversationData.datapoint = res;
@@ -58,7 +60,7 @@ module.exports = (bot, persona, datapoint, gmaps) => {
                 })
                 .catch((err) => {
                     winston.warn(err);
-                    if(err.response_id) {
+                    if (err.response_id) {
                         session.send(persona.getResponse(err.response_id));
                     } else {
                         session.send(persona.getResponse("error.data.not_returned"));

--- a/src/main/js/intents/weather/forecast.js
+++ b/src/main/js/intents/weather/forecast.js
@@ -38,7 +38,7 @@ module.exports = (bot, persona, datapoint, gmaps) => {
         utils.capture.location,
         utils.sanitze.location,
         (session, results, next) => {
-            gmaps.geocode(session.conversationData.location)
+            gmaps.geocode(utils.convData.get(session, 'location'))
                 .then((res) => {
                     session.conversationData.gmaps = res;
                     return next();
@@ -50,7 +50,7 @@ module.exports = (bot, persona, datapoint, gmaps) => {
                 });
         },
         (session, results, next) => {
-            var end = session.conversationData.time_target.range.toDT;
+            var end = utils.convData.get(session, 'time_target').range.toDT;
             datapoint.getMethodForTargetTime(end)(session.conversationData.gmaps.results[0].geometry.location.lat, session.conversationData.gmaps.results[0].geometry.location.lng)
                 .then((res) => {
                     session.conversationData.datapoint = res;
@@ -68,9 +68,9 @@ module.exports = (bot, persona, datapoint, gmaps) => {
             var response = "";
             var model = {
                 user: session.userData,
-                location: session.conversationData.location,
+                location: utils.convData.get(session, 'location'),
                 date: {
-                    day_string: session.conversationData.time_target.text
+                    day_string: utils.convData.get(session, 'time_target').text
                 }
             };
 

--- a/src/main/js/intents/weather/variable.js
+++ b/src/main/js/intents/weather/variable.js
@@ -35,7 +35,7 @@ module.exports = (bot, persona, datapoint, gmaps) => {
         utils.sanitze.datetimeV2,
         utils.capture.variable,
         (session, results, next) => {
-            gmaps.geocode(session.conversationData.location)
+            gmaps.geocode(utils.convData.get(session, 'location'))
                 .then((res) => {
                     session.conversationData.gmaps = res;
                     return next();
@@ -47,7 +47,7 @@ module.exports = (bot, persona, datapoint, gmaps) => {
                 });
         },
         (session, results, next) => {
-            var end = session.conversationData.time_target.range.toDT;
+            var end = utils.convData.get(session, 'time_target').range.toDT;
             datapoint.getMethodForTargetTime(end)(session.conversationData.gmaps.results[0].geometry.location.lat, session.conversationData.gmaps.results[0].geometry.location.lng)
                 .then((res) => {
                     session.conversationData.datapoint = res;

--- a/src/main/js/intents/weather/variable.js
+++ b/src/main/js/intents/weather/variable.js
@@ -47,7 +47,9 @@ module.exports = (bot, persona, datapoint, gmaps) => {
                 });
         },
         (session, results, next) => {
-            var end = utils.convData.get(session, 'time_target').range.toDT;
+            var range = utils.convData.get(session, 'time_target').range;
+            range = utils.time.rangeStrsToObjs(range);
+            var end = range.toDT;
             datapoint.getMethodForTargetTime(end)(session.conversationData.gmaps.results[0].geometry.location.lat, session.conversationData.gmaps.results[0].geometry.location.lng)
                 .then((res) => {
                     session.conversationData.datapoint = res;
@@ -55,7 +57,7 @@ module.exports = (bot, persona, datapoint, gmaps) => {
                 })
                 .catch((err) => {
                     winston.warn(err);
-                    if(err.response_id) {
+                    if (err.response_id) {
                         session.send(persona.getResponse(err.response_id));
                     } else {
                         session.send(persona.getResponse("error.data.not_returned"));

--- a/src/main/js/intents/weather/variableThresholdIntentBuilder.js
+++ b/src/main/js/intents/weather/variableThresholdIntentBuilder.js
@@ -55,9 +55,9 @@ module.exports = function(baseIntent, localIntent, synonyms, variableThresholds,
                     var response = "";
                     var model = {
                         user: session.userData,
-                        location: session.conversationData.location,
+                        location: utils.convData.get(session, 'location'),
                         date: {
-                            day_string: session.conversationData.time_target.text
+                            day_string: utils.convData.get(session, 'time_target').text
                         }
                     };
 

--- a/src/main/js/services/datapoint/new.js
+++ b/src/main/js/services/datapoint/new.js
@@ -13,15 +13,15 @@ module.exports = function(key) {
     var datapointCache = new cache();
 
     function getMethodForTargetTime(dt) {
-        if(sugar.Date.isBefore(dt, "now")) {
-            return function () {
-                return Promise.reject({response_id:"error.date.range.before"})
+        if (sugar.Date.isBefore(dt, "now")) {
+            return function() {
+                return Promise.reject({ response_id: "error.date.range.before" });
             }
         } else if (sugar.Date.hoursFromNow(dt) <= 40) {
             return getHourlyDataForLatLng;
-        } else if(sugar.Date.daysFromNow(dt) > 7) {
-            return function () {
-                return Promise.reject({response_id:"error.date.range.after"})
+        } else if (sugar.Date.daysFromNow(dt) > 7) {
+            return function() {
+                return Promise.reject({ response_id: "error.date.range.after" });
             }
         }
         return get3HourlyDataForLatLng;

--- a/src/main/js/services/gmaps.js
+++ b/src/main/js/services/gmaps.js
@@ -10,17 +10,6 @@ module.exports = (key) => {
 
     var gmapsCache = new cache();
 
-    function locationInUK(result) {
-        return new Promise((resolve, reject) => {
-            result.results[0].address_components.forEach((ac) => {
-                if (ac.long_name === "United Kingdom") {
-                    resolve(result);
-                }
-            });
-            reject(`[ ${result.results[0].formatted_address} ] was located but is outside of the UK`);
-        });
-    }
-
     function geocode(location) {
 
         var slug = sugar.String.underscore(location.toLowerCase());
@@ -31,9 +20,6 @@ module.exports = (key) => {
             winston.debug("getting [ %s ] from gmaps", slug);
             var uri = `https://maps.googleapis.com/maps/api/geocode/json?address=${location}&region=uk&language=en&key=${key}`;
             return httpClient.getAsJson(uri)
-                // .then((res) => {
-                //     return locationInUK(res);
-                // }) //TODO: Do we want to limit to UK only???
                 .then((res) => {
                     gmapsCache.set(slug, res, constants.DAYS_TO_MILLIS(5));
                     return res;


### PR DESCRIPTION
* Added util functions to manage conversationData with expiry
* Changes to way 'propmt' works to prevent cross conversation contamination
* Remove limit to UK commented out code
* add isRepeat to conversationData to inform child dialogs if repeat.
* Prevent action and accessory dialogs using 'old' actions/accessories when not recognising the current one.

* fix bug when data object session data is needed in more than one dialog. Shown by:

![image](https://user-images.githubusercontent.com/1567535/29083360-67ec0ef0-7c60-11e7-8651-ac77bf31763c.png)

